### PR TITLE
Remove unnecessary CUDA cache clears

### DIFF
--- a/app/processors/face_swappers.py
+++ b/app/processors/face_swappers.py
@@ -179,10 +179,6 @@ class FaceSwappers:
         io_binding.bind_input(name='input_2', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,512), buffer_ptr=embedding.data_ptr())
         io_binding.bind_output(name='output', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,3,256,256), buffer_ptr=output.data_ptr())
 
-        if self.models_processor.device == "cuda":
-            torch.cuda.synchronize()
-        elif self.models_processor.device != "cpu":
-            self.models_processor.syncvec.cpu()
         self.models_processor.models['CSCS'].run_with_iobinding(io_binding)
 
     def calc_inswapper_latent(self, source_embedding):
@@ -201,10 +197,6 @@ class FaceSwappers:
         io_binding.bind_input(name='source', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,512), buffer_ptr=embedding.data_ptr())
         io_binding.bind_output(name='output', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,3,128,128), buffer_ptr=output.data_ptr())
 
-        if self.models_processor.device == "cuda":
-            torch.cuda.synchronize()
-        elif self.models_processor.device != "cpu":
-            self.models_processor.syncvec.cpu()
         self.models_processor.models['Inswapper128'].run_with_iobinding(io_binding)
 
     def calc_swapper_latent_ghost(self, source_embedding):
@@ -229,10 +221,6 @@ class FaceSwappers:
         io_binding.bind_input(name='source', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,512), buffer_ptr=embedding.data_ptr())
         io_binding.bind_output(name='output', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,3,256,256), buffer_ptr=output.data_ptr())
 
-        if self.models_processor.device == "cuda":
-            torch.cuda.synchronize()
-        elif self.models_processor.device != "cpu":
-            self.models_processor.syncvec.cpu()
         self.models_processor.models[ISS_MODEL_NAME].run_with_iobinding(io_binding)
 
     def calc_swapper_latent_simswap512(self, source_embedding):
@@ -250,10 +238,6 @@ class FaceSwappers:
         io_binding.bind_input(name='onnx::Gemm_1', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,512), buffer_ptr=embedding.data_ptr())
         io_binding.bind_output(name='output', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,3,512,512), buffer_ptr=output.data_ptr())
 
-        if self.models_processor.device == "cuda":
-            torch.cuda.synchronize()
-        elif self.models_processor.device != "cpu":
-            self.models_processor.syncvec.cpu()
         self.models_processor.models['SimSwap512'].run_with_iobinding(io_binding)
 
     def run_swapper_ghostface(self, image, embedding, output, swapper_model='GhostFace-v2'):
@@ -284,8 +268,4 @@ class FaceSwappers:
         io_binding.bind_input(name='source', device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,512), buffer_ptr=embedding.data_ptr())
         io_binding.bind_output(name=output_name, device_type=self.models_processor.device, device_id=0, element_type=np.float32, shape=(1,3,256,256), buffer_ptr=output.data_ptr())
 
-        if self.models_processor.device == "cuda":
-            torch.cuda.synchronize()
-        elif self.models_processor.device != "cpu":
-            self.models_processor.syncvec.cpu()
         ghostfaceswap_model.run_with_iobinding(io_binding)

--- a/app/processors/models_processor.py
+++ b/app/processors/models_processor.py
@@ -246,6 +246,7 @@ class ModelsProcessor(QtCore.QObject):
         self.providers = providers
         self.provider_name = provider_name
         self.lp_mask_crop = self.lp_mask_crop.to(self.device)
+        torch.cuda.empty_cache()
 
         return self.provider_name
 
@@ -270,7 +271,6 @@ class ModelsProcessor(QtCore.QObject):
         self.delete_models()
         self.delete_models_dfm()
         self.delete_models_trt()
-        torch.cuda.empty_cache()
 
 
     def load_inswapper_iss_emap(self, model_name):

--- a/app/processors/utils/tensorrt_predictor.py
+++ b/app/processors/utils/tensorrt_predictor.py
@@ -227,8 +227,6 @@ class TensorRTPredictor:
             return buffers
 
         finally:
-            # Sincronizza il flusso CUDA prima di restituire il contesto
-            torch.cuda.synchronize()
             self.context_pool.put(pool_entry)
 
     def predict_async(self, feed_dict: Dict[str, Any], stream: torch.cuda.Stream) -> OrderedDictType[str, torch.Tensor]:
@@ -268,8 +266,6 @@ class TensorRTPredictor:
             # Sincronizza lo stream usato se diverso da quello corrente
             if stream != torch.cuda.current_stream():
                 stream.synchronize()
-            else:
-                torch.cuda.synchronize()
             self.context_pool.put(pool_entry)
 
     def cleanup(self) -> None:

--- a/app/processors/video_processor.py
+++ b/app/processors/video_processor.py
@@ -99,7 +99,6 @@ class VideoProcessor(QObject):
         else:
             graphics_view_actions.update_graphics_view(self.main_window, pixmap, frame_number,)
         self.current_frame = frame
-        torch.cuda.empty_cache()
         #Set GPU Memory Progressbar
         common_widget_actions.update_gpu_memory_progressbar(self.main_window)
     def display_next_frame(self):
@@ -381,8 +380,6 @@ class VideoProcessor(QObject):
 
             self.recording = False #Set recording as False to make sure the next process_video() call doesnt not record the video, unless the user press the record button
 
-            print("Clearing Cache")
-            torch.cuda.empty_cache()
             gc.collect()
             video_control_actions.reset_media_buttons(self.main_window)
             print("Successfully Stopped Processing")

--- a/app/ui/widgets/actions/control_actions.py
+++ b/app/ui/widgets/actions/control_actions.py
@@ -21,7 +21,6 @@ def change_execution_provider(main_window: 'MainWindow', new_provider):
 
 def change_threads_number(main_window: 'MainWindow', new_threads_number):
     main_window.video_processor.set_number_of_threads(new_threads_number)
-    torch.cuda.empty_cache()
     common_widget_actions.update_gpu_memory_progressbar(main_window)
 
 

--- a/app/ui/widgets/ui_workers.py
+++ b/app/ui/widgets/ui_workers.py
@@ -208,7 +208,6 @@ class InputFacesLoaderWorker(qtc.QThread):
                     face_id = self.face_ids[i]
                 self.thumbnail_ready.emit(image_file_path, face_img, embedding_store, pixmap, face_id)
                 i+=1
-        torch.cuda.empty_cache()
         self.finished.emit()
 
     def stop(self):


### PR DESCRIPTION
## Summary
- stop clearing CUDA cache each frame
- only clear CUDA cache when switching execution provider
- avoid GPU synchronization where output stays on GPU

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `nvidia-smi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68611103daa48321a81ac10c1e70d3b3