### PR TITLE
Add CUDA 12.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ conda install -c nvidia/label/cuda-12.4.1 cuda-runtime
 ```sh
 conda install -c conda-forge cudnn
 ```
+#### CUDA 12.8
+```sh
+conda install -c nvidia/label/cuda-12.8.0 cuda-runtime
+```
+Compatible with GPUs having compute capability 9.0 or higher (e.g., RTX 5090).
 
 ### **4. Install Additional Dependencies**  
 ```sh
@@ -80,12 +85,17 @@ conda install scikit-image
 ```sh
 pip install -r requirements_cu124.txt
 ```
+```sh
+pip install -r requirements_cu128.txt
+```
 
 ### **5. Download Models and Other Dependencies**  
 1. Download all the required models
 ```sh
 python download_models.py
 ```
+For CUDA 12.8 you can run `scripts\update_cu128.bat` to install the correct
+packages and download the models in one step.
 2. Download all the files from this [page](https://github.com/visomaster/visomaster-assets/releases/tag/v0.1.0_dp) and copy it to the ***dependencies/*** folder.
 
   **Note**: You do not need to download the Source code (zip) and Source code (tar.gz) files 

--- a/requirements_cu128.txt
+++ b/requirements_cu128.txt
@@ -1,0 +1,29 @@
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+numpy==1.26.4
+opencv-python==4.10.0.84
+scikit-image==0.21.0
+pillow==9.5.0
+onnx==1.16.1
+protobuf==4.23.2
+psutil==6.0.0
+onnxruntime-gpu==1.22.0
+packaging==24.1
+PySide6==6.8.2.1 
+kornia
+torch==2.4.1+cu128
+torchvision==0.19.1+cu128
+torchaudio==2.4.1+cu128
+tensorrt==10.6.0 --extra-index-url https://pypi.nvidia.com
+tensorrt-cu12_libs==10.6.0
+tensorrt-cu12_bindings==10.6.0
+tqdm
+ftfy
+regex
+pyvirtualcam==0.11.1
+numexpr
+onnxsim
+requests
+pyqt-toast-notification==1.3.2
+qdarkstyle
+pyqtdarktheme

--- a/scripts/update_cu128.bat
+++ b/scripts/update_cu128.bat
@@ -1,0 +1,6 @@
+@echo off
+call scripts\setenv.bat
+"%GIT_EXECUTABLE%" fetch origin main
+"%GIT_EXECUTABLE%" reset --hard origin/main
+"%PYTHON_EXECUTABLE%" -m pip install -r requirements_cu128.txt --default-timeout 100
+"%PYTHON_EXECUTABLE%" download_models.py


### PR DESCRIPTION
## Summary
- add `requirements_cu128.txt` for CUDA 12.8 wheels
- add `update_cu128.bat` helper script
- document CUDA 12.8 installation and GPU compatibility in the README

## Testing
- `python -m py_compile main.py`
- `python -m py_compile download_models.py`


------
https://chatgpt.com/codex/tasks/task_b_68614d57dd808321b46b3ad155b4165b